### PR TITLE
fix Windows line ending issues

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
 # force answers file to have Unix-style line endings
-alpine.conf eol=lf
+*/alpine.conf text eol=lf


### PR DESCRIPTION
Fixes #1 again, files read by Unix software should have Unix-style line endings.